### PR TITLE
Fix/qt parse error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ gen/*
 *.exe
 *.out
 *.app
+
+# Map cache items
+mapscache/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Plugin for rviz for displaying satellite maps loaded from the internet.
 
-![Alt text](.screenshot.png?raw=true "Fucking Awesome Dude")
+![Alt text](.screenshot.png?raw=true "Example Image")
 
 ### Usage
 

--- a/src/aerialmap_display.cpp
+++ b/src/aerialmap_display.cpp
@@ -11,9 +11,11 @@
 #include <QtGlobal>
 #include <QImage>
 
+#include <ros/ros.h>
+#include <tf/transform_listener.h>
+
 #include <boost/bind.hpp>
 #include <boost/regex.hpp>
-
 #include <FreeImage.h>
 
 #include <OGRE/OgreManualObject.h>
@@ -22,9 +24,6 @@
 #include <OGRE/OgreSceneNode.h>
 #include <OGRE/OgreTextureManager.h>
 #include <OGRE/OgreImageCodec.h>
-
-#include <ros/ros.h>
-#include <tf/transform_listener.h>
 
 #include "rviz/frame_manager.h"
 #include "rviz/ogre_helpers/grid.h"

--- a/src/aerialmap_display.h
+++ b/src/aerialmap_display.h
@@ -11,15 +11,17 @@
 #ifndef AERIAL_MAP_DISPLAY_H
 #define AERIAL_MAP_DISPLAY_H
 
+// NOTE: workaround for issue: https://bugreports.qt.io/browse/QTBUG-22829
+#ifndef Q_MOC_RUN
 #include <ros/ros.h>
 #include <ros/time.h>
 #include <rviz/display.h>
+#include <sensor_msgs/NavSatFix.h>
 
 #include <OGRE/OgreTexture.h>
 #include <OGRE/OgreMaterial.h>
 #include <OGRE/OgreVector3.h>
-
-#include <sensor_msgs/NavSatFix.h>
+#endif  //  Q_MOC_RUN
 
 #include <QObject>
 #include <QtConcurrentRun>


### PR DESCRIPTION
This branch corrects an issue that arises when building with boost 1.48 and Qt 4 on OSX w/ Indigo. It also corrects comment in readme.