### PR TITLE
Moving ref frame

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Plugin for rviz for displaying satellite maps loaded from the internet.
 
 In order to use rviz_satellite, add this package to your catkin workspace. Then add an instance of `AerialMapDisplay` to your rviz config.
 
-The `Topic` field must point to a publisher of `sensor_msgs/NavSatFix`. Note that rviz_satellite will not repeatedly reload the same GPS coordinates twice (unless you modify something in the GUI options).
+The `Topic` field must point to a publisher of `sensor_msgs/NavSatFix`. Note that rviz_satellite will not reload tiles until the robot moves more than a fixed threshold (presently about ~100 meters).
 
 You must provide an `Object URI` (or URL) from which the satellite images are loaded. rviz_satellite presently only supports the [OpenStreetMap](http://wiki.openstreetmap.org/wiki/Slippy_map_tilenames) convention for tile names.
 
@@ -26,6 +26,8 @@ Map tiles will be cached to the `mapscache` directory in the `rviz_satellite` pa
 - `Draw Under` will cause the map to be displayed below all other geometry.
 - `Zoom` is the zoom level of the map. Recommended values are 16-19, as anything smaller is _very_ low resolution. 19 is the current max.
 - `Blocks` number of adjacent blocks to load. rviz_satellite will load the central block, and this many blocks around the center. 6 is the current max.
+- `Frame Convention` is the convention for X/Y axes of the map. In `ROS` mode it uses the mapping
+(X: North, Y: West). In `libGeographic` mode it uses (X: East, Y:North).
 
 ### Questions, Bugs
 

--- a/src/aerialmap_display.cpp
+++ b/src/aerialmap_display.cpp
@@ -136,10 +136,10 @@ AerialMapDisplay::AerialMapDisplay()
       "Topic", "", QString::fromStdString(
                        ros::message_traits::datatype<sensor_msgs::NavSatFix>()),
       "nav_msgs::Odometry topic to subscribe to.", this, SLOT(updateTopic()));
- 	
-  frame_property_ = new TfFrameProperty( "Robot frame", "",
-                                         "TF frame for the moving robot.",
-                                         this, 0, false, SLOT(updateFrame()), this );
+
+  frame_property_ = new TfFrameProperty("Robot frame", "world",
+                                        "TF frame for the moving robot.", this,
+                                        0, false, SLOT(updateFrame()), this);
 
   alpha_property_ = new FloatProperty(
       "Alpha", 0.7, "Amount of transparency to apply to the map.", this,
@@ -183,7 +183,8 @@ AerialMapDisplay::AerialMapDisplay()
       "Frame Convention", "ROS", "Convention for mapping frame to the compass",
       this, SLOT(updateFrameConvention()));
   frame_convention_property_->addOptionStd("ROS", FRAME_CONVENTION_ROS);
-  frame_convention_property_->addOptionStd("libGeographic", FRAME_CONVENTION_GEO);
+  frame_convention_property_->addOptionStd("libGeographic",
+                                           FRAME_CONVENTION_GEO);
 
   //  updating one triggers reload
   updateBlocks();
@@ -238,8 +239,7 @@ void AerialMapDisplay::updateAlpha() {
 }
 
 void AerialMapDisplay::updateFrame() {
-  frame_ = frame_property_->getFrameStd();
-  ROS_INFO_STREAM("Changing robot frame to " << frame_);
+  ROS_INFO_STREAM("Changing robot frame to " << frame_property_->getFrameStd());
   transformAerialMap();
 }
 
@@ -561,13 +561,14 @@ void AerialMapDisplay::transformAerialMap() {
   pose.position.y = 0;
   pose.position.z = 0;
   
-  if (!context_->getFrameManager()->transform(frame_, ros::Time(), pose,
+  const std::string frame = frame_property_->getFrameStd();
+  if (!context_->getFrameManager()->transform(frame, ros::Time(), pose,
                                               position, orientation)) {
     ROS_DEBUG("Error transforming map '%s' from frame '%s' to frame '%s'",
-              qPrintable(getName()), frame_.c_str(), qPrintable(fixed_frame_));
+              qPrintable(getName()), frame.c_str(), qPrintable(fixed_frame_));
 
     setStatus(StatusProperty::Error, "Transform",
-              "No transform from [" + QString::fromStdString(frame_) +
+              "No transform from [" + QString::fromStdString(frame) +
                   "] to [" + fixed_frame_ + "]");
   } else {
     setStatus(StatusProperty::Ok, "Transform", "Transform OK");

--- a/src/aerialmap_display.h
+++ b/src/aerialmap_display.h
@@ -108,9 +108,6 @@ protected:
   };
   std::vector<MapObject> objects_;
 
-  std::string topic_;
-  std::string frame_;
-
   ros::Subscriber coord_sub_;
 
   //  properties
@@ -131,7 +128,7 @@ protected:
   unsigned int blocks_;
 
   //  tile management
-  boost::mutex mutex_;
+  boost::mutex mutex_;  // TODO(gareth): Mutex seems unecessary, remove this.
   bool dirty_;
   bool received_msg_;
   double ref_lat_;

--- a/src/aerialmap_display.h
+++ b/src/aerialmap_display.h
@@ -20,7 +20,6 @@
 
 #include <OGRE/OgreTexture.h>
 #include <OGRE/OgreMaterial.h>
-#include <OGRE/OgreVector3.h>
 #endif  //  Q_MOC_RUN
 
 #include <QObject>
@@ -44,6 +43,7 @@ class Property;
 class RosTopicProperty;
 class StringProperty;
 class TfFrameProperty;
+class EnumProperty;
 
 /**
  * @class AerialMapDisplay
@@ -69,6 +69,7 @@ protected Q_SLOTS:
   void updateObjectURI();
   void updateZoom();
   void updateBlocks();
+  void updateFrameConvention();
 
   //  slots for TileLoader messages
   void initiatedRequest(QNetworkRequest request);
@@ -121,6 +122,7 @@ protected:
   FloatProperty *resolution_property_;
   FloatProperty *alpha_property_;
   Property *draw_under_property_;
+  EnumProperty * frame_convention_property_;
 
   float alpha_;
   bool draw_under_;

--- a/src/aerialmap_display.h
+++ b/src/aerialmap_display.h
@@ -43,6 +43,7 @@ class IntProperty;
 class Property;
 class RosTopicProperty;
 class StringProperty;
+class TfFrameProperty;
 
 /**
  * @class AerialMapDisplay
@@ -63,6 +64,7 @@ public:
 protected Q_SLOTS:
   void updateAlpha();
   void updateTopic();
+  void updateFrame();
   void updateDrawUnder();
   void updateObjectURI();
   void updateZoom();
@@ -112,6 +114,7 @@ protected:
 
   //  properties
   RosTopicProperty *topic_property_;
+  TfFrameProperty *frame_property_;
   StringProperty *object_uri_property_;
   IntProperty *zoom_property_;
   IntProperty *blocks_property_;

--- a/src/tileloader.cpp
+++ b/src/tileloader.cpp
@@ -223,6 +223,7 @@ QUrl TileLoader::uriForTile(int x, int y) const {
 
 int TileLoader::maxTiles() const { return (1 << zoom_) - 1; }
 
+// TODO(gareth): Change to smart pointer, also add a destructor to this class.
 void TileLoader::abort() {
   tiles_.clear();
 

--- a/src/tileloader.h
+++ b/src/tileloader.h
@@ -79,7 +79,7 @@ public:
   /// Fraction of a tile to offset the origin (X).
   double originX() const { return origin_x_; }
 
-  /// Fractio of a tile to offset the origin (Y).
+  /// Fraction of a tile to offset the origin (Y).
   double originY() const { return origin_y_; }
 
   /// Convert lat/lon to a tile index with mercator projection.


### PR DESCRIPTION
This pull request includes changes :
1. Adds a frame property such that the map can be shifted in the X/Y plane with a moving robot.
2. Change the reload behavior so that reloads are triggered after a larger amount of motion (~100 meters). This will be a parameter in future. (Credit to @chataign for these last two).
3. Added a pull-down for selecting the frame convention. ROS (X/Y -> North/West) and libGeographic (X/Y -> East/North) conventions are both supported now (ROS is the default, libGeographic was the __previous__ default behavior). At present the rotation option does not actually use the quaternion in the TF, which we may wish to correct in future.
4. Some general comments on things to cleanup in future.

On the subject of __1__ and __2__, in my original use case, it was previously expected that the GPS topic would be latched (and published once) such that data would only be loaded once at the start of bag playback. However it seems more common for the topic to be constantly publishing, hence the larger reload distance and frame option for moving robots.