### PR TITLE
Fix/memory leak

### DIFF
--- a/src/aerialmap_display.cpp
+++ b/src/aerialmap_display.cpp
@@ -270,7 +270,7 @@ void
 AerialMapDisplay::navFixCallback(const sensor_msgs::NavSatFixConstPtr &msg) {
   // If the new (lat,lon) falls into a different tile then we have some
   // reloading to do.
-  if (!received_msg_ || true ||
+  if (!received_msg_ ||
       (loader_ && !loader_->insideCentreTile(msg->latitude, msg->longitude) &&
        dynamic_reload_property_->getValue().toBool())) {
     ref_lat_ = msg->latitude;

--- a/src/aerialmap_display.cpp
+++ b/src/aerialmap_display.cpp
@@ -267,7 +267,6 @@ void AerialMapDisplay::clearGeometry() {
 }
 
 void AerialMapDisplay::update(float, float) {
-  boost::mutex::scoped_lock lock(mutex_);
   //  creates all geometry, if necessary
   assembleScene();
   //  draw

--- a/src/aerialmap_display.h
+++ b/src/aerialmap_display.h
@@ -131,7 +131,6 @@ protected:
   unsigned int blocks_;
 
   //  tile management
-  boost::mutex mutex_;  // TODO(gareth): Mutex seems unecessary, remove this.
   bool dirty_;
   bool received_msg_;
   double ref_lat_;


### PR DESCRIPTION
Replaces calls to unload() with remove(), which causes the ogre shared pointer to be removed from the singleton texture/material manager. On my machine (jade, OS X 10.11) This significantly reduces the rate at which rviz consumes memory when the map is repeatedly reloaded. Care to give it a test @chataign ?