### PR TITLE
Fix/naming convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,12 @@ Map tiles will be cached to the `mapscache` directory in the `rviz_satellite` pa
 
 - `Topic` is the topic of the GPS measurements.
 - `Robot frame` should be a TF from the robot position to the fixed frame.
-- `Dynamically reload` will cause imagery to reload as the robot moves out of the center tile. This will only work if the robot frame is specified correctly.
+- `Dynamically reload` will cause imagery to reload as the robot moves out of the center tile. This will only work if the robot frame is specified correctly by TF.
 - `Alpha` is simply the display transparency.
 - `Draw Under` will cause the map to be displayed below all other geometry.
-- `Zoom` is the zoom level of the map. Recommended values are 16-19, as anything smaller is _very_ low resolution. 19 is the current max.
-- `Blocks` number of adjacent blocks to load. rviz_satellite will load the central block, and this many blocks around the center. 6 is the current max.
-- `Frame Convention` is the convention for X/Y axes of the map. In `ROS` mode it uses the mapping
-(X: North, Y: West). In `libGeographic` mode it uses (X: East, Y:North).
+- `Zoom` is the zoom level of the map. Recommended values are 16-19, as anything smaller is _very_ low resolution. 22 is the current max.
+- `Blocks` number of adjacent blocks to load. rviz_satellite will load the central block, and this many blocks around the center. 8 is the current max.
+- `Frame Convention` is the convention for X/Y axes of the map. The default is maps XYZ to ENU, which is the default convention for libGeographic and [ROS](www.ros.org/reps/rep-0103.html).
 
 ### Questions, Bugs
 

--- a/src/aerialmap_display.cpp
+++ b/src/aerialmap_display.cpp
@@ -316,8 +316,8 @@ void AerialMapDisplay::loadImagery() {
   }
 
   try {
-    loader_.reset(
-        new TileLoader(object_uri_, ref_lat_, ref_lon_, zoom_, blocks_, this));
+    loader_.reset(new TileLoader(object_uri_, ref_fix_.latitude,
+                                 ref_fix_.longitude, zoom_, blocks_, this));
   } catch (std::exception &e) {
     setStatus(StatusProperty::Error, "Message", QString(e.what()));
     return;

--- a/src/aerialmap_display.h
+++ b/src/aerialmap_display.h
@@ -131,11 +131,9 @@ protected:
   int blocks_;
 
   //  tile management
-  boost::mutex mutex_;  // TODO(gareth): Mutex seems unecessary, remove this.
   bool dirty_;
   bool received_msg_;
-  double ref_lat_;
-  double ref_lon_;
+  sensor_msgs::NavSatFix ref_fix_;
   std::shared_ptr<TileLoader> loader_;
 };
 

--- a/src/aerialmap_display.h
+++ b/src/aerialmap_display.h
@@ -127,8 +127,8 @@ protected:
   float alpha_;
   bool draw_under_;
   std::string object_uri_;
-  unsigned int zoom_;
-  unsigned int blocks_;
+  int zoom_;
+  int blocks_;
 
   //  tile management
   boost::mutex mutex_;  // TODO(gareth): Mutex seems unecessary, remove this.

--- a/src/tileloader.h
+++ b/src/tileloader.h
@@ -31,13 +31,13 @@ public:
       : x_(x), y_(y), z_(z), image_(image) {}
 
     /// X tile coordinate.
-    const int &x() const { return x_; }
+    int x() const { return x_; }
 
     /// Y tile coordinate.
-    const int &y() const { return y_; }
+    int y() const { return y_; }
       
     /// Z tile zoom value.
-    const int &z() const { return z_; }
+    int z() const { return z_; }
 
     /// Network reply.
     const QNetworkReply *reply() const { return reply_; }
@@ -71,20 +71,20 @@ public:
   double resolution() const;
 
   /// X index of central tile.
-  int tileX() const { return tile_x_; }
+  int centerTileX() const { return center_tile_x_; }
 
   /// Y index of central tile.
-  int tileY() const { return tile_y_; }
+  int centerTileY() const { return center_tile_y_; }
 
   /// Fraction of a tile to offset the origin (X).
-  double originX() const { return origin_x_; }
+  double originOffsetX() const { return origin_offset_x_; }
 
   /// Fraction of a tile to offset the origin (Y).
-  double originY() const { return origin_y_; }
+  double originOffsetY() const { return origin_offset_y_; }
 
   /// Test if (lat,lon) falls inside centre tile.
-  bool insideCentreTile( double lat, double lon ) const;
-  
+  bool insideCentreTile(double lat, double lon) const;
+
   /// Convert lat/lon to a tile index with mercator projection.
   static void latLonToTileCoords(double lat, double lon, unsigned int zoom,
                                  double &x, double &y);
@@ -138,10 +138,10 @@ private:
   double longitude_;
   unsigned int zoom_;
   int blocks_;
-  int tile_x_;
-  int tile_y_;
-  double origin_x_;
-  double origin_y_;
+  int center_tile_x_;
+  int center_tile_y_;
+  double origin_offset_x_;
+  double origin_offset_y_;
 
   std::shared_ptr<QNetworkAccessManager> qnam_;
   QString cache_path_;


### PR DESCRIPTION
- Rename frame convention menu for clarity.
- Fix issue introduced in #10 where the map could shift when transformAerialMap was triggered. The timestamp of the reference lat/lon is used in combination with the frame manager to make sure the correct TF is used, even if other options change.
- Introduce constants for max blocks, max zoom, and raise max blocks to 8.
- Rename misc variables and add comments.

Frame conventions:
libGeogrphic (actually also ROS, according to [REP103](www.ros.org/reps/rep-0103.html)) maps to 'XYZ -> ENU'
ROS (which was incorrectly named, oops) maps to 'XYZ -> NWU'