### PR TITLE
Set a HTTP user agent header

### DIFF
--- a/src/tileloader.cpp
+++ b/src/tileloader.cpp
@@ -120,7 +120,9 @@ void TileLoader::start() {
       } else {
         const QUrl uri = uriForTile(x, y);
         //  send request
-        const QNetworkRequest request = QNetworkRequest(uri);
+        QNetworkRequest request = QNetworkRequest(uri);
+        request.setHeader(QNetworkRequest::UserAgentHeader,
+                          "rviz_satellite/0.0.2 (+https://github.com/gareth-cross/rviz_satellite)");
         QNetworkReply *rep = qnam_->get(request);
         emit initiatedRequest(request);
         tiles_.push_back(MapTile(x, y, zoom_, rep));

--- a/src/tileloader.cpp
+++ b/src/tileloader.cpp
@@ -121,8 +121,8 @@ void TileLoader::start() {
         const QUrl uri = uriForTile(x, y);
         //  send request
         QNetworkRequest request = QNetworkRequest(uri);
-        request.setHeader(QNetworkRequest::UserAgentHeader,
-                          "rviz_satellite/0.0.2 (+https://github.com/gareth-cross/rviz_satellite)");
+        auto const userAgent = QByteArray("rviz_satellite/0.0.2 (+https://github.com/gareth-cross/rviz_satellite)");
+        request.setRawHeader(QByteArray("User-Agent"), userAgent);
         QNetworkReply *rep = qnam_->get(request);
         emit initiatedRequest(request);
         tiles_.push_back(MapTile(x, y, zoom_, rep));


### PR DESCRIPTION
Some tile servers (e.g. openstreetmap.org) require a valid user agent.
Fixes using http://a.tile.openstreetmap.org/{z}/{x}/{y}.png as tile url
(Object URI).