### PR TITLE
Apply clang-tidy suggestions (nullptr, override)

### DIFF
--- a/src/aerialmap_display.cpp
+++ b/src/aerialmap_display.cpp
@@ -87,7 +87,7 @@ AerialMapDisplay::AerialMapDisplay()
 
   frame_property_ = new TfFrameProperty("Robot frame", "world",
                                         "TF frame for the moving robot.", this,
-                                        0, false, SLOT(updateFrame()), this);
+                                        nullptr, false, SLOT(updateFrame()), this);
 
   dynamic_reload_property_ =
       new Property("Dynamically reload", true,
@@ -384,7 +384,7 @@ void AerialMapDisplay::assembleScene() {
 
       //  create textureing unit
       Ogre::Pass *pass = material->getTechnique(0)->getPass(0);
-      Ogre::TextureUnitState *tex_unit = NULL;
+      Ogre::TextureUnitState *tex_unit = nullptr;
       if (pass->getNumTextureUnitStates() > 0) {
         tex_unit = pass->getTextureUnitState(0);
       } else {

--- a/src/aerialmap_display.h
+++ b/src/aerialmap_display.h
@@ -54,13 +54,13 @@ class AerialMapDisplay : public Display {
   Q_OBJECT
 public:
   AerialMapDisplay();
-  virtual ~AerialMapDisplay();
+  ~AerialMapDisplay() override;
 
   // Overrides from Display
-  virtual void onInitialize();
-  virtual void fixedFrameChanged();
-  virtual void reset();
-  virtual void update(float, float);
+  void onInitialize() override;
+  void fixedFrameChanged() override;
+  void reset() override;
+  void update(float, float) override;
 
 protected Q_SLOTS:
   void updateDynamicReload();
@@ -81,8 +81,8 @@ protected Q_SLOTS:
 
 protected:
   // overrides from Display
-  virtual void onEnable();
-  virtual void onDisable();
+  void onEnable() override;
+  void onDisable() override;
 
   virtual void subscribe();
   virtual void unsubscribe();

--- a/src/tileloader.cpp
+++ b/src/tileloader.cpp
@@ -41,7 +41,7 @@ static size_t replaceRegex(const boost::regex &ex, std::string &str,
 void TileLoader::MapTile::abortLoading() {
   if (reply_) {
     reply_->abort();
-    reply_ = 0;
+    reply_ = nullptr;
   }
 }
 

--- a/src/tileloader.h
+++ b/src/tileloader.h
@@ -24,7 +24,7 @@ class TileLoader : public QObject {
 public:
   class MapTile {
   public:
-    MapTile(int x, int y, int z, QNetworkReply *reply = 0)
+    MapTile(int x, int y, int z, QNetworkReply *reply = nullptr)
         : x_(x), y_(y), z_(z), reply_(reply) {}
       
     MapTile(int x, int y, int z, QImage & image)
@@ -62,7 +62,7 @@ public:
 
   explicit TileLoader(const std::string &service, double latitude,
                       double longitude, unsigned int zoom, unsigned int blocks,
-                      QObject *parent = 0);
+                      QObject *parent = nullptr);
 
   /// Start loading tiles asynchronously.
   void start();


### PR DESCRIPTION
Marks methods as override (modernize-use-override) and uses nullptr (modernize-use-nullptr) where applicable, based on the approach described in https://www.kdab.com/clang-tidy-part-1-modernize-source-code-using-c11c14/
