### PR TITLE
synchronize tile loading and scene-object transform

### DIFF
--- a/src/aerialmap_display.h
+++ b/src/aerialmap_display.h
@@ -133,6 +133,7 @@ protected:
   //  tile management
   bool dirty_;
   bool received_msg_;
+  bool loading_;
   sensor_msgs::NavSatFix ref_fix_;
   std::shared_ptr<TileLoader> loader_;
 };


### PR DESCRIPTION
When requesting a texture update (e.g. when the robot moved towards the edge of a currently loaded tile grid), texture update and transform update are now in sync. Previously there was a clearly visible glitch while updating.