### PR TITLE
Fix opencv NOTFOUND issue with new OpenCV version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,13 @@ find_package(catkin REQUIRED COMPONENTS
   sensor_msgs
 )
 
-catkin_package(CATKIN_DEPENDS nav_msgs sensor_msgs)
+catkin_package(
+  CATKIN_DEPENDS
+    nav_msgs
+    sensor_msgs
+  DEPENDS
+    OpenCV
+)
 
 set(${PROJECT_NAME}_SOURCES
   src/aerialmap_display.cpp
@@ -75,7 +81,7 @@ endif()
 # Other includes
 include_directories(
   ${CMAKE_CURRENT_BINARY_DIR}
-  ${OpenCV_INCLUDE_DIR}
+  ${OpenCV_INCLUDE_DIRS}
   ${OGRE_OV_INCLUDE_DIRS}
   ${catkin_INCLUDE_DIRS}
   src
@@ -84,7 +90,6 @@ include_directories(
 # Other libraries
 link_libraries(
   ${QT_LIBRARIES}
-  ${OpenCV_LIBRARIES}
   ${catkin_LIBRARIES}
 )
 


### PR DESCRIPTION
There is an issue with catkin and recent OpenCV versions:
https://discourse.ros.org/t/opencv-3-3-1-is-breaking-builds-in-kinetic/3384/5

Full error:
``No rule to make target 'opencv_calib3d-NOTFOUND', needed by '/opt/ws/devel/.private/rviz_satellite/lib/librviz_satellite.so'``


Moving OpenCV as dependency into the catkin package and removing the OpenCV library linking (as it is already included into the catkin library linking) solves the issue (as [described by tfoote here](https://discourse.ros.org/t/opencv-3-3-1-is-breaking-builds-in-kinetic/3384/5)).