### PR TITLE
Remove unused opencv linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,6 @@ else()
 	include(${QT_USE_FILE})
 endif()
 
-find_package(OpenCV REQUIRED)
 find_package(PkgConfig REQUIRED)
 
 pkg_check_modules(OGRE_OV OGRE OGRE-Overlay)
@@ -75,7 +74,6 @@ endif()
 # Other includes
 include_directories(
   ${CMAKE_CURRENT_BINARY_DIR}
-  ${OpenCV_INCLUDE_DIR}
   ${OGRE_OV_INCLUDE_DIRS}
   ${catkin_INCLUDE_DIRS}
   src
@@ -84,7 +82,6 @@ include_directories(
 # Other libraries
 link_libraries(
   ${QT_LIBRARIES}
-  ${OpenCV_LIBRARIES}
   ${catkin_LIBRARIES}
 )
 


### PR DESCRIPTION
Opencv is not used in any cpp file, and it's also not specified in the package.xml. After removing, the package still builds in a fresh docker image.