### PR TITLE
Incorporate rviz Fixed Frame orientation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(DISTRO $ENV{ROS_DISTRO})
 message(STATUS "Distribution: " ${DISTRO})
 
 set(DEFAULT_BUILD_QT5 OFF)
-if(${DISTRO} STREQUAL "kinetic")
+if (${DISTRO} STREQUAL "kinetic" OR ${DISTRO} STREQUAL "melodic")
     set(DEFAULT_BUILD_QT5 ON)
 endif()
 


### PR DESCRIPTION
Incorporates the orientation of the rviz `Fixed Frame` with respect to the AerialMapDisplay `Robot frame` (side note: maybe this should be called `Map frame` or `Robot position`?) so that the map changes orientation appropriately when the view frame is changed.

The effects of this PR may be visualized with, e.g., this launch file modified from `launch/demo.launch` (toggle between `map` and `map_rot` in the rviz `Fixed Frame` view):
```
<launch>
    <!-- Send a static GPS fix to every new subscriber. Edit latitude and longitude in launch/demo.gps to use your own position. -->
    <node pkg="rostopic" type="rostopic" name="fake_gps_fix" args="pub /gps/fix sensor_msgs/NavSatFix --latch --file=$(find rviz_satellite)/launch/demo.gps" output="screen"/>

    <node
        pkg="tf2_ros"
        type="static_transform_publisher"
        name="map_rot"
        args="0 0 0 0 0 0.09983341664682815 0.9950041652780258 map map_rot"
    />

    <!-- Start rviz with a pre-configured AerialMap instance. It will use the fake GPS fix from above. -->
    <node pkg="rviz" type="rviz" name="rviz" args="-d $(find rviz_satellite)/launch/demo.rviz"/>
</launch>
```

This PR also includes #40 (compatibility for ROS Melodic).