### PR TITLE
Compiling with qt5 for melodic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(DISTRO $ENV{ROS_DISTRO})
 message(STATUS "Distribution: " ${DISTRO})
 
 set(DEFAULT_BUILD_QT5 OFF)
-if(${DISTRO} STREQUAL "kinetic")
+if(${DISTRO} STREQUAL "kinetic" OR ${DISTRO} STREQUAL "melodic")
     set(DEFAULT_BUILD_QT5 ON)
 endif()
 
@@ -103,5 +103,3 @@ install(TARGETS ${PROJECT_NAME}
 )
 
 install(FILES plugin_description.xml DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION})
-
-


### PR DESCRIPTION
Hi,

In Melodic, it produces a SIGSEV because it does not compile qith Qt5.

It is a trivial fix, but it make it works in Melodic.

Hope it helps!!!