### PR TITLE
Don't show map if transform is missing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog for package rviz_satellite
 
 Forthcoming
 -----------
+* Don't show map if transform is missing
 * Fix demo.launch
 
 1.2.0 (2019-03-07)

--- a/launch/demo.launch
+++ b/launch/demo.launch
@@ -3,7 +3,7 @@
     <node pkg="rostopic" type="rostopic" name="fake_gps_fix" args="pub /gps/fix sensor_msgs/NavSatFix --latch --file=$(find rviz_satellite)/launch/demo.gps" />
 
     <!-- Start rviz with a pre-configured AerialMap instance. It will use the fake GPS fix from above. -->
-    <node pkg="rviz" type="rviz" name="rviz" args="-d $(find rviz_satellite)/launch/demo.rviz"/>
+    <node pkg="rviz" type="rviz" name="rviz" args="-d $(find rviz_satellite)/launch/demo.rviz" output="screen" />
 
     <!-- Static fake TF transform -->
     <node pkg="tf2_ros" type="static_transform_publisher" name="static_tf_fake" args="0 0 0 0 0 0 map base_link" />

--- a/src/aerialmap_display.h
+++ b/src/aerialmap_display.h
@@ -175,6 +175,8 @@ protected:
   boost::optional<TileId> lastTileId_;
   std::string lastFixedFrame_;
 
+  bool hasWorkingTransform_ = false;
+
   /**
    * Calculate the tile width/ height in meter
    */


### PR DESCRIPTION
**Description**

It's confusing when the map is shown but the transform is missing. This
leads to the map being on a wrong place.

Fixes #51

**Test plan**

Call `roslaunch rviz_satellite demo.launch` once with the `demo.launch` as is and once without the `static_tf_fake`.

/cc @beetleskin