### PR TITLE
Add missing build dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,7 @@
   <build_depend>rviz</build_depend>
   <build_depend>nav_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
+  <build_depend>qtbase5-dev</build_depend>
 
   <run_depend>roscpp</run_depend>
   <run_depend>rviz</run_depend>


### PR DESCRIPTION
To fix this error:

```
CMake Error at /home/noblean/ros/melodic/system/src/rviz_satellite/CMakeLists.txt:28 (find_package):
  By not providing "FindQt5.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "Qt5", but
  CMake did not find one.
  Could not find a package configuration file provided by "Qt5" with any of
  the following names:
    Qt5Config.cmake
    qt5-config.cmake
  Add the installation prefix of "Qt5" to CMAKE_PREFIX_PATH or set "Qt5_DIR"
  to a directory containing one of the above files.  If "Qt5" provides a
  separate development package or SDK, be sure it has been installed.
```