### PR TITLE
Set tile fetching preference to cache

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog for package rviz_satellite
 
 Forthcoming
 -----------
+* Set tile fetching preference to cache
 * Remove the robot frame property. Instead use the frame from the NavSatFix topic
 * Fix demo.launch
 

--- a/src/detail/TileDownloader.h
+++ b/src/detail/TileDownloader.h
@@ -67,8 +67,8 @@ public:
   {
     // see https://foundation.wikimedia.org/wiki/Maps_Terms_of_Use#Using_maps_in_third-party_services
     auto const requestUrl = QUrl(QString::fromStdString(tileURL(tileId)));
-    ROS_DEBUG_STREAM_NAMED("rviz_satellite", "requesting tile from URL: " << requestUrl.toString().toStdString());
-    
+    ROS_DEBUG_STREAM_NAMED("rviz_satellite", "Loading tile " << requestUrl.toString().toStdString());
+
     QNetworkRequest request(requestUrl);
     char constexpr agent[] = "rviz_satellite/" RVIZ_SATELLITE_VERSION " (+https://github.com/gareth-cross/"
                              "rviz_satellite)";
@@ -99,12 +99,14 @@ public slots:
     }
 
     // log if tile comes from cache or web
-    QVariant fromCache = reply->attribute(QNetworkRequest::SourceIsFromCacheAttribute);
-    if (fromCache.toBool()) {
-      ROS_DEBUG_STREAM_NAMED("rviz_satellite", "Loaded tile from cache (" << url.toString().toStdString() << ")");
+    bool const fromCache = reply->attribute(QNetworkRequest::SourceIsFromCacheAttribute).toBool();
+    if (fromCache)
+    {
+      ROS_DEBUG_STREAM_NAMED("rviz_satellite", "Loaded tile from cache " << url.toString().toStdString());
     }
-    else {
-      ROS_DEBUG_STREAM_NAMED("rviz_satellite", "Loaded tile from web (" << url.toString().toStdString() << ")");
+    else
+    {
+      ROS_DEBUG_STREAM_NAMED("rviz_satellite", "Loaded tile from web " << url.toString().toStdString());
     }
 
     QImageReader reader(reply);

--- a/src/detail/TileDownloader.h
+++ b/src/detail/TileDownloader.h
@@ -66,12 +66,16 @@ public:
   void loadTile(TileId const& tileId)
   {
     // see https://foundation.wikimedia.org/wiki/Maps_Terms_of_Use#Using_maps_in_third-party_services
-    QNetworkRequest request(QUrl(QString::fromStdString(tileURL(tileId))));
+    auto const requestUrl = QUrl(QString::fromStdString(tileURL(tileId)));
+    ROS_DEBUG_STREAM_NAMED("rviz_satellite", "requesting tile from URL: " << requestUrl.toString().toStdString());
+    
+    QNetworkRequest request(requestUrl);
     char constexpr agent[] = "rviz_satellite/" RVIZ_SATELLITE_VERSION " (+https://github.com/gareth-cross/"
                              "rviz_satellite)";
     request.setHeader(QNetworkRequest::KnownHeaders::UserAgentHeader, agent);
     QVariant variant;
     variant.setValue(tileId);
+    request.setAttribute(QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::CacheLoadControl::PreferCache);
     request.setAttribute(QNetworkRequest::User, variant);
     manager->get(request);
   }
@@ -85,13 +89,22 @@ public slots:
     QUrl const url = reply->url();
     if (reply->error())
     {
-      ROS_ERROR_STREAM(reply->errorString().toStdString());
+      ROS_ERROR_STREAM("Got error when loading tile: " << reply->errorString().toStdString());
       errorRates.issueError(tileId.tileServer);
       return;
     }
     else
     {
       errorRates.issueSuccess(tileId.tileServer);
+    }
+
+    // log if tile comes from cache or web
+    QVariant fromCache = reply->attribute(QNetworkRequest::SourceIsFromCacheAttribute);
+    if (fromCache.toBool()) {
+      ROS_DEBUG_STREAM_NAMED("rviz_satellite", "Loaded tile from cache (" << url.toString().toStdString() << ")");
+    }
+    else {
+      ROS_DEBUG_STREAM_NAMED("rviz_satellite", "Loaded tile from web (" << url.toString().toStdString() << ")");
     }
 
     QImageReader reader(reply);


### PR DESCRIPTION
By default, QNetworkRequest uses a "prefer network" (CacheLoadControl::PreferNetwork) policy for querying data. Since we rather want to avoid downloading the same tile images, we set it to "prefer disk cache" (QNetworkRequest::PreferCache). 

Details: _PreferNetwork_ cache policy respects the HTTP response header field `Cache-Control`, e.g. `Cache-Control: max-age=86400`. So if the cached data is older than the max-age, the web is queried. If not, the local cache is used. This change overrides this to: always use cache, if existing.
See https://doc.qt.io/qt-5/qnetworkrequest.html for more.