### PR TITLE
Fix uninitialized variable

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Forthcoming
 -----------
 * Remove the robot frame property. Instead use the frame from the NavSatFix topic
 * Fix demo.launch
+* Fix uninitialized variable
 
 1.2.0 (2019-03-07)
 ------------------

--- a/src/aerialmap_display.cpp
+++ b/src/aerialmap_display.cpp
@@ -90,6 +90,7 @@ AerialMapDisplay::AerialMapDisplay() : Display(), dirty_(false), received_msg_(f
   blocks_property_->setShouldBeSaved(true);
   blocks_property_->setMin(0);
   blocks_property_->setMax(maxBlocks);
+  blocks_ = -1;
 
   frame_convention_property_ =
       new EnumProperty("Frame Convention", "XYZ -> ENU", "Convention for mapping cartesian frame to the compass", this,
@@ -97,9 +98,6 @@ AerialMapDisplay::AerialMapDisplay() : Display(), dirty_(false), received_msg_(f
   frame_convention_property_->addOptionStd("XYZ -> ENU", FRAME_CONVENTION_XYZ_ENU);
   frame_convention_property_->addOptionStd("XYZ -> NED", FRAME_CONVENTION_XYZ_NED);
   frame_convention_property_->addOptionStd("XYZ -> NWU", FRAME_CONVENTION_XYZ_NWU);
-
-  //  updating one triggers reload
-  updateBlocks();
 }
 
 AerialMapDisplay::~AerialMapDisplay()


### PR DESCRIPTION
There was an uninitialized variable that was causing warnings when
the plugin was used in debug mode.