### PR TITLE
Fix missing build_depend on qtbase5-dev

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -9,9 +9,10 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>nav_msgs</build_depend>
+  <build_depend>qtbase5-dev</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>rviz</build_depend>
-  <build_depend>nav_msgs</build_depend>
   <build_depend>sensor_msgs</build_depend>
 
   <run_depend>roscpp</run_depend>


### PR DESCRIPTION
This package uses FindQt5.cmake so it should have qtbase5-dev as
dependency. This fixes building this package in our CI.