### PR TITLE
Remove NED and NWU frame conversion options

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package rviz_satellite
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Remove NED and NWU frame conversion options
+
 2.0.0 (2020-04-17)
 ------------------
 * Drop Qt4 support

--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ Please refer to the respective terms of service and copyrights.
 - `Draw Under` will cause the map to be displayed below all other geometry.
 - `Zoom` is the zoom level of the map. Recommended values are 16-19, as anything smaller is _very_ low resolution. 22 is the current max.
 - `Blocks` number of adjacent blocks to load. rviz_satellite will load the central block, and this many blocks around the center. 8 is the current max.
-- `Frame Convention` is the convention for X/Y axes of the map. The default is maps XYZ to ENU, which is the default convention for libGeographic and [ROS](www.ros.org/reps/rep-0103.html).
 
 ## Support and Contributions
 

--- a/launch/demo.rviz
+++ b/launch/demo.rviz
@@ -37,11 +37,9 @@ Visualization Manager:
       Class: rviz_plugins/AerialMapDisplay
       Draw Behind: false
       Enabled: true
-      Frame Convention: XYZ -> ENU
       Name: AerialMapDisplay
       Object URI: https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}.png
       Topic: /gps/fix
-      Value: true
       Zoom: 18
     - Class: rviz/Axes
       Enabled: true

--- a/src/aerialmap_display.h
+++ b/src/aerialmap_display.h
@@ -53,7 +53,6 @@ class Property;
 class RosTopicProperty;
 class StringProperty;
 class TfFrameProperty;
-class EnumProperty;
 
 /**
  * @class AerialMapDisplay
@@ -78,7 +77,6 @@ protected Q_SLOTS:
   void updateTileUrl();
   void updateZoom();
   void updateBlocks();
-  void updateFrameConvention();
 
 protected:
   // overrides from Display
@@ -148,7 +146,6 @@ protected:
   FloatProperty* resolution_property_;
   FloatProperty* alpha_property_;
   Property* draw_under_property_;
-  EnumProperty* frame_convention_property_;
 
   float alpha_;
   bool draw_under_;


### PR DESCRIPTION
With [REP 105](https://www.ros.org/reps/rep-0105.html), ROS defines the fixed map-frame/world frame to be in ENU coordinates. It also seemed that no one is using other world-frame definitions. We make our transform-lives easier by removing this additional transform.

**Test Plan:**
- check that it works exactly as before when setting the frame conversion to ENU