### PR TITLE
Fix time synchronization of NavSat transform lookup

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog for package rviz_satellite
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Fix time synchronization of NavSat transform lookup
+
 3.0.1 (2020-08-03)
 ------------------
 * Fix cleanup bug breaking the navsat-tile transforms (#84, #85)

--- a/src/aerialmap_display.h
+++ b/src/aerialmap_display.h
@@ -23,6 +23,7 @@ limitations under the License. */
 #include <ros/time.h>
 #include <rviz/display.h>
 #include <sensor_msgs/NavSatFix.h>
+#include <tf2_ros/buffer.h>
 
 #include <OGRE/OgreMaterial.h>
 #include <OGRE/OgreVector3.h>
@@ -124,15 +125,6 @@ protected:
   void transformMapTileToFixedFrame();
 
   /**
-   * Get the transform from frame_id w.r.t. the map-frame
-   *
-   * @return true if the transform lookup was successful
-   * @return false if the transform lookup failed
-   */
-  bool getMapTransform(std::string const& query_frame, ros::Time const& timestamp, Ogre::Vector3& position,
-                       Ogre::Quaternion& orientation, std::string& error);
-
-  /**
    * Checks how may tiles were loaded successfully, and sets the status accordingly.
    */
   void checkRequestErrorRate();
@@ -189,6 +181,9 @@ protected:
   Ogre::Vector3 t_centertile_map_{ Ogre::Vector3::ZERO };
   /// the map frame, rigidly attached to the world with ENU convention - see https://www.ros.org/reps/rep-0105.html#map
   std::string static const MAP_FRAME;
+
+  /// buffer for tf lookups not related to fixed-frame
+  std::shared_ptr<tf2_ros::Buffer const> tf_buffer_{ nullptr };
 };
 
 }  // namespace rviz


### PR DESCRIPTION
Previously, the FrameManager's tf cache was used to look this up. However, this cache is not suitable since its designed for render-frame timings and only for the RViz' fixed-frame. Using the normal TfBuffer resolves some tile offsets when tf is not perfectly up to date.

**Test-Plan:**
@schra Run with different flavors of our stack, confirm watertight transforms (no glitches left, always correct drawing).